### PR TITLE
Fix state attribute in dynamic volume API bindings

### DIFF
--- a/pkg/internal/apis/dynamicvolume/v1/common_genclient.go
+++ b/pkg/internal/apis/dynamicvolume/v1/common_genclient.go
@@ -40,6 +40,10 @@ func endpointURL(ctx context.Context, o types.Object, apiPath string) (*url.URL,
 	return u, nil
 }
 
+type commonRequestBody struct {
+	State string `json:"state,omitempty"`
+}
+
 func requestBody(ctx context.Context, br func() interface{}) (interface{}, error) {
 	op, err := types.OperationFromContext(ctx)
 	if err != nil {

--- a/pkg/internal/apis/dynamicvolume/v1/volume_genclient.go
+++ b/pkg/internal/apis/dynamicvolume/v1/volume_genclient.go
@@ -9,6 +9,7 @@ import (
 func (v *Volume) FilterAPIRequestBody(ctx context.Context) (interface{}, error) {
 	return requestBody(ctx, func() interface{} {
 		return &struct {
+			commonRequestBody
 			Volume
 			StorageServerInterfaces *string `json:"storage_server_interfaces,omitempty"`
 			Prefixes                *string `json:"prefixes,omitempty"`


### PR DESCRIPTION
### Description

Fixed request state string attribute to be omitted instead of zero-val.
<!--- Please leave a helpful description of the pull request here. --->

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References
I messed up testing [this change](https://github.com/anexia/csi-driver/pull/3#discussion_r1069225813), by testing against a previous version. I think  we should find a better solution for the state attribute in `go-anxcloud` and adjust to this change when moving the bindings there.
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
