### PR TITLE
Adjust test volume size parameter in sanity test config

### DIFF
--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -24,6 +24,7 @@ func TestDriver(t *testing.T) {
 		// todo: read from env
 		"csi.anx.io/storage-server-identifier": "2014322f13e54dfb82c491b961df12c7", // csi-test
 	}
+	config.TestVolumeSize = 1024 * 1024 * 1024 // 1 GiB
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
To mitigate a huge amount of reserved storage due to sanity test volumes pending in the recovery queue, we decided to lower the `TestVolumeSize` parameter.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
