### PR TITLE
CI: always upload test artifact

### DIFF
--- a/.github/workflows/sanity-tests.yml
+++ b/.github/workflows/sanity-tests.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@v3
+        if: ${{ always() }}
         with:
           name: csi-driver.log
           path: csi-driver.log


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
This PR fixes the sanity test workflow to also upload logging artifacts when it was canceled

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
