### PR TITLE
Bump alpine from 3.18.0 to 3.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go mod download
 COPY . .
 RUN go build -ldflags "-s -w -X github.com/anexia/csi-driver/pkg/version.Version=$version" ./cmd/csi-driver
 
-FROM alpine:3.18.0
+FROM alpine:3.18.2
 
 # Hadolint wants us to pin apk packages to specific versions, mostly to make sure sudden incompatible changes
 # don't get released - for ca-certificates this only gives us the downside of randomly failing docker builds


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Bumps alpine from 3.18.0 to 3.18.2.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
