### PR TITLE
Ensure IP addresses on storage server interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Fixed
+
+* Ensure that IP address is set when querying the storage server interface (#223, @nachtjasmin)
+
 ## [0.1.1] - 2024-03-14
 
 ### Fixed

--- a/pkg/controller/errors.go
+++ b/pkg/controller/errors.go
@@ -19,4 +19,9 @@ var (
 
 	// ErrVolumeWithSameNameButDifferentSizeAlreadyExists is returned if a volume with the same name but different size already exists
 	ErrVolumeWithSameNameButDifferentSizeAlreadyExists = errors.New("volume with the same name, but different size already exists")
+
+	// ErrQueryingIPAddressesFailed is returned whenever we actually receive a
+	// storage server interface from the Engine, but that has no IP addresses. This is
+	// almost always due to missing IPAM permissions.
+	ErrQueryingIPAddressesFailed = errors.New("engine returned no IP addresses for storage server interface, likely due to missing permissions on the token")
 )

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -178,6 +178,10 @@ func getDynamicStorageServer(ctx context.Context, engine types.API, req *csi.Cre
 		return nil, err
 	}
 
+	if storageServer.IPAddress.Name == "" {
+		return nil, ErrQueryingIPAddressesFailed
+	}
+
 	return &storageServer, nil
 }
 

--- a/pkg/controller/utils_test.go
+++ b/pkg/controller/utils_test.go
@@ -229,6 +229,7 @@ var _ = Describe("Controller Service Utils", func() {
 		It("can successfully resolve a server with valid `csi.anx.io/storage-server-identifier` set", func() {
 			a.EXPECT().Get(gomock.Any(), &dynamicvolumev1.StorageServerInterface{Identifier: "foobar"}).DoAndReturn(func(_ any, s *dynamicvolumev1.StorageServerInterface, _ ...any) error {
 				s.Name = "test-name"
+				s.IPAddress.Name = "127.0.0.1"
 				return nil
 			})
 
@@ -255,6 +256,21 @@ var _ = Describe("Controller Service Utils", func() {
 
 			Expect(err).To(MatchError(api.ErrNotFound))
 			Expect(storageServer).To(BeNil())
+		})
+
+		It("returns an error when IP addresses are empty", func() {
+			a.EXPECT().Get(gomock.Any(), &dynamicvolumev1.StorageServerInterface{Identifier: "foobar"}).DoAndReturn(func(_ any, s *dynamicvolumev1.StorageServerInterface, _ ...any) error {
+				s.Name = "test-name"
+				return nil
+			})
+
+			_, err := getDynamicStorageServer(context.TODO(), a, &csi.CreateVolumeRequest{
+				Parameters: map[string]string{
+					"csi.anx.io/storage-server-identifier": "foobar",
+				},
+			})
+
+			Expect(err).To(MatchError(ErrQueryingIPAddressesFailed))
 		})
 	})
 


### PR DESCRIPTION

### Description
As part of SESUP-94, it happened that the permissions were missing to query the IP addresses. This ended up in invalid mounts which weren't even removable properly, cause the driver assumed that everything as working.

To prevent invalid mounts again, this check now verifies whether we have an IP address set and if not, it returns an error.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
