### PR TITLE
chore: update README about storage expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,8 @@ spec:
 EOF
 ```
 
+### Storage expansion
+
+We currently do not support the `allowVolumeExpansion` field.
+
 Consult the [Kubernetes CSI Developer Documentation](https://kubernetes-csi.github.io/docs/support-fsgroup.html) for further information.


### PR DESCRIPTION
### Description

Updates the README about explicitely not supporting the `allowVolumeExpansion` field.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
