### PR TITLE
Add detailed logs for easier debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Added
+
+* Add detailed logs for the whole CSI workflow to assist in debugging. (#286, @nachtjasmin)
+
 ## [0.1.3] - 2025-02-14
 
 ### Fixed

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -47,21 +47,28 @@ func (ns node) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*c
 }
 
 func (ns node) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+	l := ns.logger.V(2).WithValues("id", req.VolumeId, "path", req.GetTargetPath())
+	l.Info("Trying to mount volume")
+
 	if err := checkNodePublishVolumeRequest(req); err != nil {
+		l.Error(err, "NodePublishVolumeRequest invalid")
 		return nil, status.Errorf(codes.InvalidArgument, "invalid NodePublishVolumeRequest: %s", err)
 	}
 
 	opts := req.GetVolumeCapability().GetMount().GetMountFlags()
-
 	if req.GetReadonly() {
+		l.Info("Volume will be mounted as read-only")
 		opts = append(opts, "ro")
 	}
 
+	l.Info("Validating target path")
 	// adapted from https://github.com/kubernetes-csi/csi-driver-nfs/blob/f084312ad0a3c05b720466db7f8721db2aec6a66/pkg/nfs/nodeserver.go#L108
 	notMount, err := ns.mounter.IsLikelyNotMountPoint(req.GetTargetPath())
 	if err != nil {
 		if os.IsNotExist(err) {
+			l.Info("Creating new directory at target path", "target_path", req.GetTargetPath())
 			if err := os.Mkdir(req.GetTargetPath(), os.FileMode(os.ModeDir)); err != nil {
+				l.Error(err, "Directory at target path failed")
 				return nil, status.Errorf(codes.Internal, "error creating target directory: %q", err)
 			}
 
@@ -72,27 +79,36 @@ func (ns node) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolume
 	}
 
 	if !notMount {
-		klog.V(4).Infof("NodePublishVolume: Mount already present at target path %q.", req.TargetPath)
+		klog.V(2).Infof("NodePublishVolume: Mount already present at target path %q.", req.TargetPath)
 		return &csi.NodePublishVolumeResponse{}, nil
 	}
 
+	l.Info("Mounting volume to target path")
 	mountURL := req.GetVolumeContext()["mountURL"]
-
 	if err := ns.mounter.Mount(mountURL, req.GetTargetPath(), "nfs", opts); err != nil {
+		l.Error(err, "Mounting volume failed")
 		return nil, status.Errorf(codes.Internal, "error mounting volume: %s", err)
 	}
 
+	l.Info("Volume mounted successfully")
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
 func (ns node) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+	l := ns.logger.V(2).WithValues("id", req.VolumeId, "path", req.GetTargetPath())
+	l.Info("Trying to unmount volume")
+
 	if err := checkNodeUnpublishVolumeRequest(req); err != nil {
+		l.Error(err, "NodeUnpublishVolumeRequest invalid")
 		return nil, status.Errorf(codes.InvalidArgument, "invalid NodeUnpublishVolumeRequest: %s", err)
 	}
 
+	l.Info("Cleaning up mount path")
 	if err := mount.CleanupMountPoint(req.GetTargetPath(), ns.mounter, true); err != nil {
+		l.Error(err, "Cleaning up mount path failed")
 		return nil, status.Errorf(codes.Internal, "error cleaning up mount point: %s", err)
 	}
 
+	l.Info("Volume successfully unmounted")
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }


### PR DESCRIPTION
Especially when debugging csi-drivers that are not installed in one of our managed Kubernetes Clusters, it's hard to understand where errors actually might occur due to missing logs.

By adding the logs, issues like ANXSUP-115235 can be easier analysed.

Closes ANXKUBE-1366

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
