### PR TITLE
Add support for volume expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Added
+
+* Add support for volume expansion. (#291, @nachtjasmin)
+
+  StorageClasses now support the `allowVolumeExpansion: true` parameter, allowing for an *online*
+  resizing of existing PersistentVolumeClaims.
+
+  Right now, the csi-resize container is just added as a sidecar to the existing controller.
+  We plan to extract this into a separate deployment in the near future.
+
 ## [0.1.5] -- 2025-05-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ provisioner: csi.anx.io
 parameters:
   csi.anx.io/ads-class: ENT2
   csi.anx.io/storage-server-identifier: $STORAGE_SERVER_INTERFACE_ID
+allowVolumeExpansion: true
 EOF
 ```
 
@@ -87,9 +88,5 @@ spec:
   fsGroupPolicy: File
 EOF
 ```
-
-### Storage expansion
-
-For now, we do not support the `allowVolumeExpansion` field. If you want to expand the volumes, you can do so using the Anexia Engine by editing a volume.
 
 Consult the [Kubernetes CSI Developer Documentation](https://kubernetes-csi.github.io/docs/support-fsgroup.html) for further information.

--- a/deploy/kubernetes/driver.yaml
+++ b/deploy/kubernetes/driver.yaml
@@ -86,6 +86,16 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
+        # TODO: Put this into a separate deployment with a dedicated RBAC role.
+        - name: csi-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.13.2
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --leader-election
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -1,5 +1,5 @@
-# adapted from https://github.com/kubernetes-csi/csi-driver-nfs/blob/master/deploy/rbac-csi-nfs.yaml
 ---
+# adapted from https://github.com/kubernetes-csi/csi-driver-nfs/blob/master/deploy/rbac-csi-nfs.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -47,6 +47,13 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get"]
+  # required for resizing
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/controller/controller_volume_expansion.go
+++ b/pkg/controller/controller_volume_expansion.go
@@ -1,0 +1,45 @@
+package controller
+
+import (
+	"context"
+
+	dynamicvolumev1 "github.com/anexia/csi-driver/pkg/internal/apis/dynamicvolume/v1"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"k8s.io/klog/v2"
+)
+
+// ControllerExpandVolume implements the support for the [Volume Expansion API].
+//
+// ControllerExpandVolume RPC call can be made when volume is ONLINE or OFFLINE
+// depending on VolumeExpansion plugin capability. Where ONLINE and OFFLINE means:
+//
+//   - ONLINE : Volume is currently published or available on a node.
+//   - OFFLINE : Volume is currently not published or available on a node.
+//
+// Because ADV supports online volume expansion, no implementation of NodeExpandVolume is required.
+// This is indicated by the NodeExpansionRequired field in the response, which is always set to false.
+//
+// [Volume Expansion API]: https://kubernetes-csi.github.io/docs/volume-expansion.html
+func (cs *controller) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
+	klog.V(2).InfoS("Expanding volume", "id", req.GetVolumeId(), "request", req)
+
+	newCapacityBytes := sizeFromCapacityRange(req.CapacityRange)
+
+	klog.V(2).InfoS("Updating ADV volume to resize to new capacity", "new_capacity_bytes", newCapacityBytes)
+	v := dynamicvolumev1.Volume{
+		Identifier: req.GetVolumeId(),
+		Size:       newCapacityBytes,
+	}
+	if err := cs.engine.Update(ctx, &v); err != nil {
+		klog.V(2).ErrorS(err, "ADV volume could not be updated", "id", req.GetVolumeId())
+		return nil, engineErrorToGRPC(err)
+	}
+
+	klog.V(2).InfoS("Volume expanded successfully", "id", req.GetVolumeCapability())
+	return &csi.ControllerExpandVolumeResponse{
+		CapacityBytes: newCapacityBytes,
+
+		// There's no adjustment required on the node itself, the mountpoint will continue to work as previously.
+		NodeExpansionRequired: false,
+	}, nil
+}

--- a/pkg/controller/controller_volume_expansion_test.go
+++ b/pkg/controller/controller_volume_expansion_test.go
@@ -1,0 +1,84 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	dynamicvolumev1 "github.com/anexia/csi-driver/pkg/internal/apis/dynamicvolume/v1"
+	"github.com/anexia/csi-driver/pkg/internal/mockapi"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/golang/mock/gomock"
+)
+
+func TestControllerExpandVolume(t *testing.T) {
+	t.Parallel()
+
+	type testBundle struct {
+		controller *controller
+		api        *mockapi.MockAPI
+	}
+	setup := func(t *testing.T) testBundle {
+		t.Helper()
+
+		ctrl := gomock.NewController(t)
+		api := mockapi.NewMockAPI(ctrl)
+
+		return testBundle{
+			controller: &controller{engine: api},
+			api:        api,
+		}
+	}
+
+	t.Run("engine errors are properly returned", func(t *testing.T) {
+		t.Parallel()
+		var (
+			bundle = setup(t)
+			ctx    = context.TODO()
+		)
+
+		bundle.api.EXPECT().
+			Update(gomock.Any(), gomock.Eq(&dynamicvolumev1.Volume{
+				Identifier: "expand-volume",
+				Size:       oneGibibyteInBytes,
+			})).
+			Return(errors.New("mock error"))
+
+		_, err := bundle.controller.ControllerExpandVolume(ctx, &csi.ControllerExpandVolumeRequest{
+			VolumeId:      "expand-volume",
+			CapacityRange: &csi.CapacityRange{RequiredBytes: oneGibibyteInBytes},
+		})
+		if err == nil {
+			t.Fatalf("Expected error, got none")
+		}
+		if !strings.Contains(err.Error(), "mock error") {
+			t.Fatalf("Expected substring 'mock error' inside error message, got: %s", err)
+		}
+	})
+	t.Run("engine is called with proper parameters", func(t *testing.T) {
+		t.Parallel()
+		var (
+			bundle = setup(t)
+			ctx    = context.TODO()
+		)
+
+		bundle.api.EXPECT().
+			Update(gomock.Any(), gomock.Eq(&dynamicvolumev1.Volume{
+				Identifier: "expand-volume",
+				Size:       oneGibibyteInBytes,
+			})).
+			Return(nil)
+
+		resp, err := bundle.controller.ControllerExpandVolume(ctx, &csi.ControllerExpandVolumeRequest{
+			VolumeId:      "expand-volume",
+			CapacityRange: &csi.CapacityRange{RequiredBytes: oneGibibyteInBytes},
+		})
+		if err != nil {
+			t.Fatalf("Expected no error, got %#v", err)
+		}
+		if resp.CapacityBytes != oneGibibyteInBytes {
+			t.Fatalf("Returned capacity in bytes does not match expected value, got %d, want %d", resp.CapacityBytes, oneGibibyteInBytes)
+		}
+	})
+}

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -101,6 +101,12 @@ func sizeFromCapacityRange(capacityRange *csi.CapacityRange) int64 {
 		size = capacityRange.GetLimitBytes()
 	}
 
+	// If we exceed the maximum, limit it to that.
+	if size > maxVolumeSize {
+		klog.V(0).Infof("The size request of %d bytes exceeds the maximum value (%d). Falling back to the maximum value.", size, maxVolumeSize)
+		size = maxVolumeSize
+	}
+
 	return size
 }
 

--- a/pkg/controller/utils_test.go
+++ b/pkg/controller/utils_test.go
@@ -296,6 +296,7 @@ var _ = Describe("Controller Service Utils", func() {
 			Entry("required bytes set", &csi.CapacityRange{RequiredBytes: 20}, int64(20)),
 			// probably shouldn't ever happen...
 			Entry("required bytes greater than limit", &csi.CapacityRange{RequiredBytes: 20, LimitBytes: 10}, int64(10)),
+			Entry("max capacity exceeded", &csi.CapacityRange{RequiredBytes: maxVolumeSize + 1}, maxVolumeSize),
 		)
 	})
 })

--- a/pkg/internal/apis/dynamicvolume/v1/common_genclient.go
+++ b/pkg/internal/apis/dynamicvolume/v1/common_genclient.go
@@ -3,7 +3,6 @@ package v1
 import (
 	"net/url"
 
-	"go.anx.io/go-anxcloud/pkg/api"
 	"go.anx.io/go-anxcloud/pkg/api/types"
 	"go.anx.io/go-anxcloud/pkg/utils/object/filter"
 	"golang.org/x/net/context"
@@ -13,10 +12,6 @@ func endpointURL(ctx context.Context, o types.Object, apiPath string) (*url.URL,
 	op, err := types.OperationFromContext(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	if op == types.OperationUpdate {
-		return nil, api.ErrOperationNotSupported
 	}
 
 	// we can ignore the error since the URL is hard-coded known as valid


### PR DESCRIPTION
This adds volume expansion support to the CSI driver. As per the discussion in SO-14229, we keep the limit as is. The expansion is handled by another controller, which, in our deployment, is added as a sidecar.

In the future, we should change this to be a proper deployment with it's own ServiceAccount. I decided to do it this way to keep the changes in this PR to a minimum and expect this to be cleaned up in a future release.

Closes ANXKUBE-1367

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
