### PR TITLE
Turn StorageClass parameters into simple map[string]string

### DIFF
--- a/deploy/kubernetes/class.yaml
+++ b/deploy/kubernetes/class.yaml
@@ -6,4 +6,4 @@ metadata:
 provisioner: csi.anx.io
 parameters:
   csi.anx.io/ads-class: ENT2
-  csi.anx.io/storage-server-identifier: { "doc": "insert identifier of storage server interface here" }
+  csi.anx.io/storage-server-identifier: '' # Insert identifier of storage server interface here.


### PR DESCRIPTION
The old, nested "doc" parameter did not allow for strategic merge patches via a Kustomization. This complicated transition steps of ANXKUBE-1407 and therefore I decided to remove the invalid syntax by an empty string.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
