### PR TITLE
controller: Add error handling for mount path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ Some examples, more below in the actual changelog (newer entries are more likely
 * (internal) generic client: add hook FilterRequestURLHook (#123, @marioreggiori)
 
 -->
+
+### Fixed
+
+* Add proper error check for volume mount paths (#298, @nachtjasmin)
+
 ## [0.1.6] -- 2025-05-22
 
 Smaller style changes.

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -200,6 +200,21 @@ func getDynamicStorageServer(ctx context.Context, engine types.API, req *csi.Cre
 	return &storageServer, nil
 }
 
-func createMountURL(volume *dynamicvolumev1.Volume, storageServer *dynamicvolumev1.StorageServerInterface) string {
-	return fmt.Sprintf("%s:%s", storageServer.IPAddress.Name, volume.Path)
+// createMountURL builds the NFS mount URL that's going to be used.
+//
+// An error is returned, if the URL cannot be constructed, because one of the required values is empty.
+func createMountURL(volume *dynamicvolumev1.Volume, storageServer *dynamicvolumev1.StorageServerInterface) (string, error) {
+	var (
+		ip   = storageServer.IPAddress.Name
+		path = volume.Path
+	)
+
+	if ip == "" {
+		return "", fmt.Errorf("IP not provided on storage server interface")
+	}
+	if path == "" {
+		return "", fmt.Errorf("volume without a path yet")
+	}
+
+	return fmt.Sprintf("%s:%s", ip, path), nil
 }

--- a/pkg/controller/utils_test.go
+++ b/pkg/controller/utils_test.go
@@ -279,9 +279,23 @@ var _ = Describe("Controller Service Utils", func() {
 			volume := dynamicvolumev1.Volume{Path: "/foo/bar"}
 			storageServer := dynamicvolumev1.StorageServerInterface{IPAddress: dynamicvolumev1.IPAddress{Name: "1.2.3.4"}}
 
-			mountURL := createMountURL(&volume, &storageServer)
+			mountURL, _ := createMountURL(&volume, &storageServer)
 
 			Expect(mountURL).To(Equal("1.2.3.4:/foo/bar"))
+		})
+		It("returns an error if volume path is missing", func() {
+			volume := dynamicvolumev1.Volume{}
+			storageServer := dynamicvolumev1.StorageServerInterface{IPAddress: dynamicvolumev1.IPAddress{Name: "1.2.3.4"}}
+
+			_, err := createMountURL(&volume, &storageServer)
+			Expect(err).To(HaveOccurred())
+		})
+		It("returns an error if IP is missing", func() {
+			volume := dynamicvolumev1.Volume{Path: "/foo/bar"}
+			storageServer := dynamicvolumev1.StorageServerInterface{IPAddress: dynamicvolumev1.IPAddress{Name: ""}}
+
+			_, err := createMountURL(&volume, &storageServer)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
createMountURL needs error checking to not craft invalid mount paths. A simple string comparison is sufficient for most cases and lays the groundwork for future improvements in this area.

Related: SESUP-118, SODEV-495
Closes: ANXKUBE-1433

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
