### PR TITLE
Reprovision failed volumes automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Added
+
+* Reprovision failed volumes automatically (#305, @nachtjasmin)
+
 ## [0.1.9] -- 2025-07-17
 
 * Increase storage limit to 10TiB (@nachtjasmin) (@nachtjasmin)


### PR DESCRIPTION

### Description

Reprovisions failed volumes automatically, as per discussion with the SO  team.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
